### PR TITLE
Fix --debug option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -232,9 +232,9 @@
       }
     },
     "circular-json": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
-      "integrity": "sha1-vos2rvzN6LPKeqLWr8B6NyQsDS0=",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
       "dev": true
     },
     "cli-cursor": {
@@ -305,6 +305,17 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
+    "cross-spawn": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "4.1.1",
+        "shebang-command": "1.2.0",
+        "which": "1.2.14"
+      }
+    },
     "cryptiles": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
@@ -335,6 +346,11 @@
       "requires": {
         "ms": "2.0.0"
       }
+    },
+    "debugged": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/debugged/-/debugged-0.1.0.tgz",
+      "integrity": "sha512-nqocMxLMC+i3ex5DkcvxeO1GVVZ+UImhIQWEyV7QzJoWsd+lTZKOn+DNt6KWPwhzxmXNA+k8eXj9yB0RiNa9ow=="
     },
     "deep-is": {
       "version": "0.1.3",
@@ -387,15 +403,16 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.2.0.tgz",
-      "integrity": "sha1-orMYQRGxmOAunH88ymJaXgHFaz0=",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.3.0.tgz",
+      "integrity": "sha1-/NfJY3a780yF7mftABKimWQrEI8=",
       "dev": true,
       "requires": {
         "ajv": "5.2.2",
         "babel-code-frame": "6.22.0",
         "chalk": "1.1.3",
         "concat-stream": "1.6.0",
+        "cross-spawn": "5.1.0",
         "debug": "2.6.8",
         "doctrine": "2.0.0",
         "eslint-scope": "3.7.1",
@@ -404,6 +421,7 @@
         "estraverse": "4.2.0",
         "esutils": "2.0.2",
         "file-entry-cache": "2.0.0",
+        "functional-red-black-tree": "1.0.1",
         "glob": "7.1.2",
         "globals": "9.18.0",
         "ignore": "3.3.3",
@@ -422,6 +440,7 @@
         "pluralize": "4.0.0",
         "progress": "2.0.0",
         "require-uncached": "1.0.3",
+        "semver": "5.3.0",
         "strip-json-comments": "2.0.1",
         "table": "4.0.1",
         "text-table": "0.2.0"
@@ -587,7 +606,7 @@
       "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
       "dev": true,
       "requires": {
-        "circular-json": "0.3.1",
+        "circular-json": "0.3.3",
         "del": "2.2.2",
         "graceful-fs": "4.1.11",
         "write": "0.2.1"
@@ -612,6 +631,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
     },
     "getpass": {
       "version": "0.1.7",
@@ -775,7 +800,7 @@
         "run-async": "2.3.0",
         "rx-lite": "4.0.8",
         "rx-lite-aggregates": "4.0.8",
-        "string-width": "2.1.0",
+        "string-width": "2.1.1",
         "strip-ansi": "4.0.0",
         "through": "2.3.8"
       },
@@ -786,26 +811,6 @@
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
-        "ansi-styles": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.1.0.tgz",
-          "integrity": "sha1-CcIC1ckX7CMYjKpcnLkXnNlUd1A=",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.0.1.tgz",
-          "integrity": "sha512-Mp+FXEI+FrwY/XYV45b2YD3E8i3HwnEAoFcM0qlZzq/RZ9RwWitt2Y/c7cqRAz70U7hfekqx6qNYthuKFO6K0g==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.1.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.2.0"
-          }
-        },
         "strip-ansi": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -813,15 +818,6 @@
           "dev": true,
           "requires": {
             "ansi-regex": "3.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.0.tgz",
-          "integrity": "sha512-Ts0Mu/A1S1aZxEJNG88I4Oc9rcZSBFNac5e27yh4j2mqbhZSSzR1Ah79EYwSn9Zuh7lrlGD2cVGzw1RKGzyLSg==",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
           }
         }
       }
@@ -880,6 +876,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
     "isstream": {
@@ -998,6 +1000,16 @@
       "resolved": "https://registry.npmjs.org/lodash.trim/-/lodash.trim-4.5.1.tgz",
       "integrity": "sha1-NkJefukL5KpeJ7zruFt9EepHqlc="
     },
+    "lru-cache": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+      "dev": true,
+      "requires": {
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
+      }
+    },
     "mime-db": {
       "version": "1.27.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
@@ -1025,6 +1037,12 @@
         "brace-expansion": "1.1.8"
       }
     },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
@@ -1032,14 +1050,6 @@
       "dev": true,
       "requires": {
         "minimist": "0.0.8"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
-        }
       }
     },
     "ms": {
@@ -1173,6 +1183,12 @@
       "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
       "dev": true
     },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
+    },
     "punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
@@ -1296,6 +1312,27 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
+    "semver": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+      "dev": true
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -1354,9 +1391,9 @@
       }
     },
     "string-width": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.0.tgz",
-      "integrity": "sha1-AwZkVh/BRslCPsfZeP4kV0N/5tA=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
         "is-fullwidth-code-point": "2.0.0",
@@ -1419,7 +1456,7 @@
         "chalk": "1.1.3",
         "lodash": "4.17.4",
         "slice-ansi": "0.0.4",
-        "string-width": "2.1.0"
+        "string-width": "2.1.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -1532,6 +1569,15 @@
         "extsprintf": "1.0.2"
       }
     },
+    "which": {
+      "version": "1.2.14",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+      "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
+      "dev": true,
+      "requires": {
+        "isexe": "2.0.0"
+      }
+    },
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
@@ -1551,6 +1597,12 @@
       "requires": {
         "mkdirp": "0.5.1"
       }
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "chalk": "^2.0.1",
     "commander": "^2.11.0",
     "debug": "^2.6.8",
+    "debugged": "^0.1.0",
     "glob": "^7.1.2",
     "http-status-codes": "^1.1.6",
     "lodash.defaultsdeep": "^4.6.0",
@@ -38,7 +39,7 @@
     "right-pad": "^1.0.1"
   },
   "devDependencies": {
-    "eslint": "^4.2.0",
+    "eslint": "^4.3.0",
     "eslint-config-notninja": "^0.2.3"
   },
   "bin": {

--- a/src/CLI.js
+++ b/src/CLI.js
@@ -26,8 +26,8 @@
 
 const chalk = require('chalk');
 const Command = require('commander').Command;
-const debugModule = require('debug');
-const debug = debugModule('throne:cli');
+const Debugged = require('debugged');
+const debug = Debugged.create('throne:cli');
 const EOL = require('os').EOL;
 const groupBy = require('lodash.groupby');
 const rightPad = require('right-pad');
@@ -132,7 +132,7 @@ class CLI {
       .option('-d, --debug', 'enable debug level logging')
       .option('-s, --service <title>', 'filter service by title', (s, list) => list.concat(s), [])
       .option('--stack', 'print stack traces for errors')
-      .on('option:debug', () => debugModule.enable('*'));
+      .on('option:debug', () => Debugged.enable('*'));
 
     this[_command].command('check <name>')
       .alias('chk')
@@ -197,7 +197,7 @@ class CLI {
       args = [];
     }
 
-    debug('Parsing arguments: %o', args);
+    debug.log('Parsing arguments: %o', args);
 
     this[_command].parse(args);
 
@@ -217,7 +217,7 @@ class CLI {
         return Math.max(acc, `${descriptor.category} > ${descriptor.title}`.length);
       }, 0);
 
-      debug('Calculated maximum length for service descriptor: %d', maxLength);
+      debug.log('Calculated maximum length for service descriptor: %d', maxLength);
     });
 
     throne.addListener('checkservice', (event) => {

--- a/src/Throne.js
+++ b/src/Throne.js
@@ -23,7 +23,7 @@
 'use strict';
 
 const async = require('async');
-const debug = require('debug')('throne');
+const debug = require('debugged').create('throne');
 const EventEmitter = require('events').EventEmitter;
 const trim = require('lodash.trim');
 
@@ -52,7 +52,7 @@ class Throne extends EventEmitter {
 
     this[_serviceManager] = new ServiceManager();
 
-    debug('Initialized Throne');
+    debug.log('Initialized Throne');
   }
 
   /**
@@ -83,7 +83,7 @@ class Throne extends EventEmitter {
 
     name = trim(name).toLowerCase();
 
-    debug('Checking "%s" using options: %o', name, options);
+    debug.log('Checking "%s" using options: %o', name, options);
 
     return this[_serviceManager].get({ filter: options.filter })
       .then((services) => this[_checkServices](name, options, services))
@@ -105,7 +105,7 @@ class Throne extends EventEmitter {
       options = {};
     }
 
-    debug('Listing services and categories using options: %o', options);
+    debug.log('Listing services and categories using options: %o', options);
 
     return this[_serviceManager].get({ filter: options.filter })
       .then((services) => services.map((service) => service.descriptor));
@@ -114,7 +114,7 @@ class Throne extends EventEmitter {
   [_checkService](name, options, service) {
     const descriptor = service.descriptor;
 
-    debug('Checking "%s" using %s service under %s category', name, descriptor.title, descriptor.category);
+    debug.log('Checking "%s" using %s service under %s category', name, descriptor.title, descriptor.category);
 
     /**
      * The "checkservice" event is fired immediately before a service is checked.
@@ -135,7 +135,7 @@ class Throne extends EventEmitter {
           name
         }, descriptor);
 
-        debug('Check succeeded for "%s" using %s service: %o', name, descriptor.title, result);
+        debug.log('Check succeeded for "%s" using %s service: %o', name, descriptor.title, result);
 
         return result;
       })
@@ -146,7 +146,7 @@ class Throne extends EventEmitter {
           name
         }, descriptor);
 
-        debug('Check failed for "%s" using %s service: %o', name, descriptor.title, result);
+        debug.log('Check failed for "%s" using %s service: %o', name, descriptor.title, result);
 
         return result;
       })
@@ -198,7 +198,7 @@ class Throne extends EventEmitter {
   }
 
   [_generateReport](name, results) {
-    debug('Generating report for "%s" based on results: %o', name, results);
+    debug.log('Generating report for "%s" based on results: %o', name, results);
 
     const stats = {
       available: 0,
@@ -229,7 +229,7 @@ class Throne extends EventEmitter {
       unique: stats.failed ? null : stats.available === stats.passed
     };
 
-    debug('Report generated for "%s": %o', name, report);
+    debug.log('Report generated for "%s": %o', name, report);
 
     /**
      * The "report" event is fired once all services have been checked along with a report containing all of their

--- a/src/service/HttpService.js
+++ b/src/service/HttpService.js
@@ -22,7 +22,7 @@
 
 'use strict';
 
-const debug = require('debug')('throne:service');
+const debug = require('debugged').create('throne:service');
 const defaultsDeep = require('lodash.defaultsdeep');
 const HttpStatus = require('http-status-codes');
 const pollock = require('pollock');
@@ -96,17 +96,17 @@ class HttpService extends Service {
         timeout: options.timeout
       });
 
-      debug('Sending HTTP request for %s service: %o', this.descriptor.title, requestOptions);
+      debug.log('Sending HTTP request for %s service: %o', this.descriptor.title, requestOptions);
 
       request(requestOptions, (error, response) => {
         if (error) {
-          debug('HTTP request for %s service failed: %s', this.descriptor.title, error);
+          debug.log('HTTP request for %s service failed: %s', this.descriptor.title, error);
 
           reject(error);
         } else {
           const statusCode = response.statusCode;
 
-          debug('HTTP request for %s service responded with status code: %d', this.descriptor.title, statusCode);
+          debug.log('HTTP request for %s service responded with status code: %d', this.descriptor.title, statusCode);
 
           if (this.getAcceptedStatusCodes().indexOf(statusCode) === -1) {
             let statusText;
@@ -120,7 +120,7 @@ class HttpService extends Service {
               message += ` - ${statusText}`;
             }
 
-            debug('%s service rejected HTTP response status code: %d (%s)', this.descriptor.title, statusCode,
+            debug.log('%s service rejected HTTP response status code: %d (%s)', this.descriptor.title, statusCode,
               statusText || '?');
 
             reject(new Error(message));
@@ -128,11 +128,11 @@ class HttpService extends Service {
             try {
               const result = this.checkResponse(name, response);
 
-              debug('%s service determined available from HTTP response: %s', this.descriptor.title, result);
+              debug.log('%s service determined available from HTTP response: %s', this.descriptor.title, result);
 
               resolve(result);
             } catch (e) {
-              debug('%s service failed when checking HTTP response', this.descriptor.title);
+              debug.log('%s service failed when checking HTTP response', this.descriptor.title);
 
               reject(e);
             }

--- a/src/service/ServiceManager.js
+++ b/src/service/ServiceManager.js
@@ -24,7 +24,7 @@
 
 /* eslint global-require: "off" */
 
-const debug = require('debug')('throne:service');
+const debug = require('debugged').create('throne:service');
 const glob = require('glob');
 const path = require('path');
 const sortBy = require('lodash.sortby');
@@ -90,10 +90,10 @@ class ServiceManager {
    * @public
    */
   load() {
-    debug('Loading available services');
+    debug.log('Loading available services');
 
     if (this[_services]) {
-      debug('%d services have previously been loaded', this[_services].length);
+      debug.log('%d services have previously been loaded', this[_services].length);
 
       return Promise.resolve(this[_services].slice());
     }
@@ -109,7 +109,7 @@ class ServiceManager {
 
           const service = new ServiceImpl(category);
 
-          debug('Loaded %s service under %s category', service.descriptor.title, service.descriptor.category);
+          debug.log('Loaded %s service under %s category', service.descriptor.title, service.descriptor.category);
 
           return service;
         }), [
@@ -117,7 +117,7 @@ class ServiceManager {
           (service) => service.descriptor.title.toUpperCase()
         ]);
 
-        debug('Loaded %d services within %d categories', services.length, categories.size);
+        debug.log('Loaded %d services within %d categories', services.length, categories.size);
 
         this[_services] = services;
 
@@ -137,7 +137,7 @@ class ServiceManager {
   unload() {
     this[_services] = null;
 
-    debug('Unloaded all services');
+    debug.log('Unloaded all services');
   }
 
   [_findServiceFiles]() {


### PR DESCRIPTION
The `--debug` option is currently not working as expected as the `debug` module does not automatically refresh the enabled status for debug instances when changed. For this reason, I've created and added the `debugged` module that provides a wrapper for the `debug` module that provides singleton instances (per namespace) as well as the ability to automatically refresh the enabled status when changed globally.